### PR TITLE
[joern] Fix lambda CFG out-edge parsing error

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -2467,6 +2467,9 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     closureBindings: Seq[ClosureBindingInfo],
     refEdgePairs: Seq[RefEdgePair]
   ): Ast = {
+
+    scopeStack.pushNewScope(NewMethod())
+
     val signature    = lambdaSignature(expr.getParameters.asScala.toList)
     val lineNumber   = line(expr)
     val columnNumber = column(expr)
@@ -2506,6 +2509,8 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
     val lambdaMethodAstWithRefEdges = refEdgePairs.foldLeft(lambdaMethodAst)((acc, edgePair) => {
       acc.withRefEdge(edgePair.from, edgePair.to)
     })
+
+    scopeStack.popScope()
 
     lambdaMethodAstWithRefEdges
   }


### PR DESCRIPTION
Error was:
```
Exception in thread "Writer" java.lang.RuntimeException: Edge with type='CFG' with direction='OUT' not supported by nodeType='METHOD_RETURN'
```