### PR TITLE
[javasrc2cpg] Prevent subst type infinite loops

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/util/TypeInfoCalculator.scala
@@ -94,7 +94,8 @@ class TypeInfoCalculator(global: Global, symbolResolver: SymbolResolver) {
         val typeParamDecl      = typeVariable.asTypeParameter()
         val substitutedTypeOpt = Try(typeParamValues.getValue(typeParamDecl)).toOption
         // This is the way the library tells us there is no substitution happened.
-        if (substitutedTypeOpt.isDefined) {
+        // Also, prevent infinite looping with the equals check.
+        if (substitutedTypeOpt.isDefined && !typ.equals(substitutedTypeOpt.get)) {
           val extendsBoundOption = Try(typeParamDecl.getBounds.asScala.find(_.isExtends)).toOption
           val isTypeVarOpt       = Try(substitutedTypeOpt.get.isTypeVariable).toOption
           if (

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/BindingTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/BindingTests.scala
@@ -56,21 +56,18 @@ class BindingTests extends JavaSrcCode2CpgFixture {
         .map(binding => (binding.name, binding.signature, binding.methodFullName))
         .l
       methodBinding should contain theSameElementsAs List(
-        ("accept", "void(java.lang.Number)", "SomeConsumer.accept:void(java.lang.Number)"),
-        ("accept", "void(java.lang.Object)", "SomeConsumer.accept:void(java.lang.Number)")
+        ("accept", "void(java.lang.Object)", "SomeConsumer.accept:void(java.lang.Object)")
       )
     }
 
-    "have three bindings for OtherConsumer" in {
+    "have one binding for OtherConsumer" in {
       val typeDecl = cpg.typeDecl(".*OtherConsumer.*").head
       val methodBinding = typeDecl.methodBinding
         .name("accept")
         .map(binding => (binding.name, binding.signature, binding.methodFullName))
         .l
       methodBinding should contain theSameElementsAs List(
-        ("accept", "void(java.lang.Integer)", "OtherConsumer.accept:void(java.lang.Integer)"),
-        ("accept", "void(java.lang.Number)", "OtherConsumer.accept:void(java.lang.Integer)"),
-        ("accept", "void(java.lang.Object)", "OtherConsumer.accept:void(java.lang.Integer)")
+        ("accept", "void(java.lang.Object)", "OtherConsumer.accept:void(java.lang.Object)")
       )
     }
   }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/CallTests.scala
@@ -91,7 +91,7 @@ class NewCallTests extends JavaSrcCode2CpgFixture {
         |""".stripMargin)
 
     "have correct methodFullName" in {
-      cpg.call("foo").methodFullName.head shouldBe "Foo.foo:void(java.lang.Number)"
+      cpg.call("foo").methodFullName.head shouldBe "Foo.foo:void(java.lang.Object)"
     }
   }
 

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/GenericsTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/GenericsTests.scala
@@ -144,8 +144,8 @@ class GenericsTests extends JavaSrcCodeToCpgFixture {
   "it should handle generics with upper bounds" in {
     cpg.method.name("idK").l match {
       case method :: Nil =>
-        method.fullName shouldBe "Box.idK:java.lang.Number(java.lang.Number)"
-        method.signature shouldBe "java.lang.Number(java.lang.Number)"
+        method.fullName shouldBe "Box.idK:java.lang.Object(java.lang.Object)"
+        method.signature shouldBe "java.lang.Object(java.lang.Object)"
 
       case res => fail(s"Expected method idK but found $res")
     }
@@ -154,8 +154,8 @@ class GenericsTests extends JavaSrcCodeToCpgFixture {
   "it should handle generics with compound upper bounds" in {
     cpg.method.name("idKC").l match {
       case method :: Nil =>
-        method.fullName shouldBe "Box.idKC:java.lang.Number(java.lang.Number)"
-        method.signature shouldBe "java.lang.Number(java.lang.Number)"
+        method.fullName shouldBe "Box.idKC:java.lang.Object(java.lang.Object)"
+        method.signature shouldBe "java.lang.Object(java.lang.Object)"
 
       case res => fail(s"Expected method idKC but found $res")
     }
@@ -164,8 +164,8 @@ class GenericsTests extends JavaSrcCodeToCpgFixture {
   "it should handle generics with an interface upper bound" in {
     cpg.method.name("idC").l match {
       case method :: Nil =>
-        method.fullName shouldBe "Box.idC:java.lang.Comparable(java.lang.Comparable)"
-        method.signature shouldBe "java.lang.Comparable(java.lang.Comparable)"
+        method.fullName shouldBe "Box.idC:java.lang.Object(java.lang.Object)"
+        method.signature shouldBe "java.lang.Object(java.lang.Object)"
 
       case res => fail(s"Expected method idC but found $res")
     }

--- a/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodParameterTests.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/test/scala/io/joern/javasrc2cpg/querying/MethodParameterTests.scala
@@ -66,7 +66,7 @@ class MethodParameterTests2 extends JavaSrcCode2CpgFixture {
           |""".stripMargin)
       "have correct type for parameter p1" in {
         val List(param) = cpg.method.name("foo").parameter.name("p1").l
-        param.typeFullName shouldBe "java.lang.Number"
+        param.typeFullName shouldBe "java.lang.Object"
       }
     }
 
@@ -80,7 +80,7 @@ class MethodParameterTests2 extends JavaSrcCode2CpgFixture {
           |""".stripMargin)
       "have correct type for parameter p1" in {
         val List(param) = cpg.method.name("foo").parameter.name("p1").l
-        param.typeFullName shouldBe "java.lang.Number"
+        param.typeFullName shouldBe "java.lang.Object"
       }
     }
 
@@ -110,7 +110,7 @@ class MethodParameterTests2 extends JavaSrcCode2CpgFixture {
 
       "have correct type for parameter p1" in {
         val List(param) = cpg.method.name("foo").parameter.name("p1").l
-        param.typeFullName shouldBe "java.lang.Number"
+        param.typeFullName shouldBe "java.lang.Object"
       }
     }
 
@@ -125,7 +125,7 @@ class MethodParameterTests2 extends JavaSrcCode2CpgFixture {
 
       "have correct type for parameter p1" in {
         val List(param) = cpg.method.name("foo").parameter.name("p1").l
-        param.typeFullName shouldBe "java.lang.Number"
+        param.typeFullName shouldBe "java.lang.Object"
       }
     }
   }


### PR DESCRIPTION
Triggered by templated classes, where the template type was used in variables or method definitions. Note for future self: the printed stack trace did not accurately reflect the true nature of the infinite looping.

Example of triggering code:

```java
package org.apache.hadoop.fs.viewfs;
public class ViewFs extends AbstractFileSystem {
  private abstract class WrappingRemoteIterator<T extends FileStatus>
      implements RemoteIterator<T> {

    @Override
    public T next() throws IOException {
    }

    protected abstract T getViewFsFileStatus(T status, Path newPath);
  }
}
```