### PR TITLE
[javasrc2cpg] Prevent Scala REPL hangs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,8 @@ ThisBuild / compile / javacOptions ++= Seq(
 )
 
 ThisBuild / scalacOptions ++= Seq(
-  "-deprecation" // Emit warning and location for usages of deprecated APIs.
+  "-deprecation", // Emit warning and location for usages of deprecated APIs.
+  "-Yrepl-class-based"
 )
 
 lazy val createDistribution = taskKey[File]("Create a complete Joern distribution")

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGenerator.scala
@@ -25,8 +25,8 @@ abstract class CpgGenerator() {
       System.err.println(s"CPG generator does not exist at: $program")
       return None
     }
-    val cmd       = Seq[String](program) ++ arguments
-    val exitValue = cmd.run().exitValue()
+    val cmd            = Seq[String](program) ++ arguments
+    lazy val exitValue = cmd.run().exitValue()
     if (exitValue == 0) {
       Some(cmd.toString)
     } else {

--- a/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/CpgGeneratorFactory.scala
@@ -60,7 +60,7 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
     outputPath: String,
     namespaces: List[String] = List()
   ): Option[Path] = {
-    val outputFileOpt: Option[File] =
+    lazy val outputFileOpt: Option[File] =
       frontend.generate(inputPath, outputPath, namespaces).map(File(_))
     outputFileOpt.map { outFile =>
       val parentPath = outFile.parent.path.toAbsolutePath

--- a/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/joern/console/cpgcreation/ImportCode.scala
@@ -127,7 +127,7 @@ class ImportCode[T <: Project](console: io.joern.console.Console[T]) {
     val name = Option(projectName).filter(_.nonEmpty).getOrElse(deriveNameFromInputPath(inputPath, workspace))
     report(s"Creating project `$name` for code at `$inputPath`")
 
-    val cpgMaybe = for {
+    lazy val cpgMaybe = for {
       pathToProject <- workspace.createProject(inputPath, name)
       frontendCpgOutFile = pathToProject.resolve(nameOfLegacyCpgInProject)
       _   <- generatorFactory.runGenerator(frontend, inputPath, frontendCpgOutFile.toString, namespaces)

--- a/joern-cli/frontends/javasrc2cpg/build.sbt
+++ b/joern-cli/frontends/javasrc2cpg/build.sbt
@@ -8,12 +8,14 @@ dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->t
 libraryDependencies ++= Seq(
   "io.shiftleft"            %% "codepropertygraph"             % Versions.cpg,
   "org.apache.logging.log4j" % "log4j-slf4j-impl"              % Versions.log4j     % Runtime,
-  "com.github.javaparser"    % "javaparser-symbol-solver-core" % "3.24.2",
+  "com.github.javaparser"    % "javaparser-symbol-solver-core" % "3.24.3-SNAPSHOT",
+  //"com.github.javaparser"    % "javaparser-symbol-solver-core" % "3.24.2",
   "org.scalatest"           %% "scalatest"                     % Versions.scalatest % Test
 )
 
 scalacOptions ++= Seq(
-  "-deprecation" // Emit warning and location for usages of deprecated APIs.
+  "-deprecation", // Emit warning and location for usages of deprecated APIs.
+  "-Yrepl-class-based"
 )
 
 enablePlugins(JavaAppPackaging, LauncherJarPlugin)

--- a/joern-cli/frontends/javasrc2cpg/build.sbt
+++ b/joern-cli/frontends/javasrc2cpg/build.sbt
@@ -8,8 +8,8 @@ dependsOn(Projects.dataflowengineoss, Projects.x2cpg % "compile->compile;test->t
 libraryDependencies ++= Seq(
   "io.shiftleft"            %% "codepropertygraph"             % Versions.cpg,
   "org.apache.logging.log4j" % "log4j-slf4j-impl"              % Versions.log4j     % Runtime,
-  "com.github.javaparser"    % "javaparser-symbol-solver-core" % "3.24.3-SNAPSHOT",
-  //"com.github.javaparser"    % "javaparser-symbol-solver-core" % "3.24.2",
+  //"com.github.javaparser"    % "javaparser-symbol-solver-core" % "3.24.3-SNAPSHOT",
+  "com.github.javaparser"    % "javaparser-symbol-solver-core" % "3.24.2",
   "org.scalatest"           %% "scalatest"                     % Versions.scalatest % Test
 )
 

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreationPass.scala
@@ -26,15 +26,15 @@ class AstCreationPass(codeDir: String, filenames: List[String], inferenceJarPath
     extends ConcurrentWriterCpgPass[String](cpg) {
 
   val global: Global              = new Global()
-  private val logger              = LoggerFactory.getLogger(classOf[AstCreationPass])
+  lazy private val logger         = LoggerFactory.getLogger(classOf[AstCreationPass])
   lazy private val symbolResolver = createSymbolSolver()
 
   override def generateParts(): Array[String] = filenames.toArray
 
   override def runOnPart(diffGraph: DiffGraphBuilder, filename: String): Unit = {
-    val parserConfig = new ParserConfiguration().setSymbolResolver(symbolResolver)
-    val parser       = new JavaParser(parserConfig)
-    val parseResult  = parser.parse(new java.io.File(filename))
+    lazy val parserConfig = new ParserConfiguration().setSymbolResolver(symbolResolver)
+    lazy val parser       = new JavaParser(parserConfig)
+    lazy val parseResult  = parser.parse(new java.io.File(filename))
 
     parseResult.getProblems.asScala.toList match {
       case Nil => // Just carry on as usual

--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/passes/AstCreator.scala
@@ -260,7 +260,6 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
 
       scopeStack.pushNewScope(namespaceScopeNode)
       addImportsToScope(compilationUnit)
-
       val typeDeclAsts = withOrder(compilationUnit.getTypes) { (typ, order) =>
         astForTypeDecl(typ, order, astParentType = "NAMESPACE_BLOCK", astParentFullName = namespaceBlockFullName)
       }
@@ -987,7 +986,6 @@ class AstCreator(filename: String, javaParserAst: CompilationUnit, global: Globa
   }
 
   private def astForMethod(methodDeclaration: MethodDeclaration): Ast = {
-
     scopeStack.pushNewScope(NewMethod())
 
     val typeParamMap = getTypeParameterMap(methodDeclaration.getTypeParameters.asScala)


### PR DESCRIPTION
This might not be needed, but adding anyway due to known, potential issues with the Scala REPL.

Source:
- [Lazy vals](https://users.scala-lang.org/t/solved-parseq-operration-hangs-in-repl/3369)
- [Compiler options](https://docs.scala-lang.org/overviews/compiler-options/index.html) ([more discussion](https://github.com/scala/bug/issues/11319))
- [ForkJoinPool parallelism issues](https://stackoverflow.com/questions/5493399/forkjoinpool-parallelism-1-deadlock) ([more discussion](https://stackoverflow.com/questions/50077315/fork-join-pool-hangs))