### PR TITLE
[javasrc2cpg] Catch comment node errors

### DIFF
--- a/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
+++ b/joern-cli/frontends/javasrc2cpg/src/main/scala/io/joern/javasrc2cpg/JavaSrc2Cpg.scala
@@ -70,7 +70,11 @@ class JavaSrc2Cpg extends X2CpgFrontend[Config] {
       javaparserAsts.typesAsts.map(_.compilationUnit).foreach(symbolSolver.inject)
 
       val astCreationPass = new AstCreationPass(javaparserAsts.analysisAsts, config, cpg, symbolSolver)
-      astCreationPass.createAndApply()
+      try {
+        astCreationPass.createAndApply()
+      } catch {
+        case e: RuntimeException => logger.error(s"EXCEPTION in file  ${config.inputPath}!!! ${e.getMessage}")
+      }
       new ConfigFileCreationPass(config.inputPath, cpg).createAndApply()
       new TypeNodePass(astCreationPass.global.usedTypes.keys().asScala.toList, cpg).createAndApply()
       new TypeInferencePass(cpg).createAndApply()


### PR DESCRIPTION
This fix catches and ignores errors like the one below. Otherwise, the CPG doesn't finish processing and many input source files would be ignored.

The real fix would involve fixing wherever arg-adjacent comments are written with an IN-edge (requires a deep investigation), or mark them as ignorable (requires changing the `codepropertygraph` codebase).

```
java.lang.RuntimeException: Failure in diffgraph application
        at io.shiftleft.passes.ConcurrentWriterCpgPass.createApplySerializeAndStore(ParallelCpgPass.scala:114)
        at io.shiftleft.passes.NewStyleCpgPassBase.createAndApply(CpgPass.scala:124)
        at io.joern.javasrc2cpg.JavaSrc2Cpg.$anonfun$createCpg$1(JavaSrc2Cpg.scala:73)
        at io.joern.javasrc2cpg.JavaSrc2Cpg.$anonfun$createCpg$1$adapted(JavaSrc2Cpg.scala:63)
        at io.joern.x2cpg.X2Cpg$.$anonfun$withNewEmptyCpg$2(X2Cpg.scala:190)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
        at scala.util.Try$.apply(Try.scala:210)
        at io.joern.x2cpg.X2Cpg$.$anonfun$withNewEmptyCpg$1(X2Cpg.scala:190)
        at scala.util.Try$.apply(Try.scala:210)
        at io.joern.x2cpg.X2Cpg$.withNewEmptyCpg(X2Cpg.scala:187)
        at io.joern.javasrc2cpg.JavaSrc2Cpg.createCpg(JavaSrc2Cpg.scala:63)
        at io.joern.javasrc2cpg.JavaSrc2Cpg.createCpg(JavaSrc2Cpg.scala:58)
        at io.joern.x2cpg.X2CpgFrontend.$anonfun$run$1(X2Cpg.scala:74)
        at io.joern.x2cpg.X2Cpg$.withErrorsToConsole(X2Cpg.scala:204)
        at io.joern.x2cpg.X2CpgFrontend.run(X2Cpg.scala:73)
        at io.joern.x2cpg.X2CpgFrontend.run$(X2Cpg.scala:72)
        at io.joern.javasrc2cpg.JavaSrc2Cpg.run(JavaSrc2Cpg.scala:58)
        at io.joern.javasrc2cpg.Main$.run(Main.scala:55)
        at io.joern.javasrc2cpg.Main$.run(Main.scala:53)
        at io.joern.x2cpg.X2CpgMain.delayedEndpoint$io$joern$x2cpg$X2CpgMain$1(X2Cpg.scala:47)
        at io.joern.x2cpg.X2CpgMain$delayedInit$body.apply(X2Cpg.scala:36)
        at scala.Function0.apply$mcV$sp(Function0.scala:39)
        at scala.Function0.apply$mcV$sp$(Function0.scala:39)
        at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:17)
        at scala.App.$anonfun$main$1(App.scala:76)
        at scala.App.$anonfun$main$1$adapted(App.scala:76)
        at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
        at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
        at scala.collection.AbstractIterable.foreach(Iterable.scala:926)
        at scala.App.main(App.scala:76)
        at scala.App.main$(App.scala:74)
        at io.joern.x2cpg.X2CpgMain.main(X2Cpg.scala:36)
        at io.joern.javasrc2cpg.Main.main(Main.scala)
Caused by: java.lang.RuntimeException: Edge with type='ARGUMENT' with direction='IN' not supported by nodeType='COMMENT'
        at overflowdb.NodeDb.storeAdjacentNode(NodeDb.java:637)
        at overflowdb.NodeDb.storeAdjacentNode(NodeDb.java:616)
        at overflowdb.NodeDb.addEdgeSilentImpl(NodeDb.java:324)
        at overflowdb.Node.addEdgeSilentInternal(Node.java:37)
        at overflowdb.NodeRef.addEdgeSilentImpl(NodeRef.java:168)
        at overflowdb.Node.addEdgeSilentInternal(Node.java:37)
        at overflowdb.BatchedUpdate$DiffGraphApplier.applyChange(BatchedUpdate.java:304)
        at overflowdb.BatchedUpdate$DiffGraphApplier.run(BatchedUpdate.java:249)
        at overflowdb.BatchedUpdate.applyDiff(BatchedUpdate.java:17)
        at io.shiftleft.passes.ConcurrentWriterCpgPass$Writer.run(ParallelCpgPass.scala:151)
        at java.base/java.lang.Thread.run(Thread.java:829)
```